### PR TITLE
Fixes for internal MPI initialization and syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -611,11 +611,11 @@ else
 endif # END IF BUILT CORE CHECK
 
 ifeq "$(SHARELIB)" "true"
-	FFLAGS += "-fPIC"
-	CFLAGS += "-fPIC"
-	CXXFLAGS += "-fPIC"
-	override CPPFLAGS += "-fPIC"
-	LDFLAGS += "-fPIC"
+	FFLAGS += -fPIC
+	CFLAGS += -fPIC
+	CXXFLAGS += -fPIC
+	override CPPFLAGS += -fPIC
+	LDFLAGS += -fPIC
 endif #SHARELIB IF
 
 ifneq ($(wildcard namelist.$(NAMELIST_SUFFIX)), ) # Check for generated namelist file.

--- a/src/driver/mpas.F
+++ b/src/driver/mpas.F
@@ -14,11 +14,11 @@ program mpas
    type (core_type), pointer :: corelist
    type (domain_type), pointer :: domain_ptr
 
-   call mpas_init(corelist,domain_ptr)
+   call mpas_init(corelist, domain_ptr)
 
    call mpas_run(domain_ptr) 
 
-   call mpas_finalize(corelist,domain_ptr)
+   call mpas_finalize(corelist, domain_ptr)
 
    stop
 

--- a/src/driver/mpas_subdriver.F
+++ b/src/driver/mpas_subdriver.F
@@ -154,8 +154,8 @@ module mpas_subdriver
 
       call mpas_allocate_domain(domain_ptr)
 
-      if (present(mpi_comm)) domainID = domainID + 1
-      domain_ptr % domainID = domainID + 1
+      domainID = domainID + 1
+      domain_ptr % domainID = domainID
 
       !
       ! Initialize infrastructure
@@ -362,7 +362,7 @@ module mpas_subdriver
    end subroutine mpas_run
 
 
-   subroutine mpas_finalize(corelist,domain_ptr)
+   subroutine mpas_finalize(corelist, domain_ptr)
 
       use mpas_stream_manager, only : MPAS_stream_mgr_finalize
       use mpas_log, only : mpas_log_finalize, mpas_log_info

--- a/src/framework/mpas_dmpar.F
+++ b/src/framework/mpas_dmpar.F
@@ -349,7 +349,9 @@ include 'mpif.h'
 #ifdef _MPI
       integer :: mpi_ierr, mpi_errcode
 
-      call MPI_Abort(dminfo % comm, mpi_errcode, mpi_ierr)
+      if ( dminfo % initialized_mpi ) then
+         call MPI_Abort(dminfo % comm, mpi_errcode, mpi_ierr)
+      end if
 #endif
 
       stop

--- a/src/framework/mpas_log.F
+++ b/src/framework/mpas_log.F
@@ -176,10 +176,13 @@ module mpas_log
       mpas_log_info % taskID = domain % dminfo % my_proc_id
       mpas_log_info % nTasks = domain % dminfo % nprocs
 
-      ! Store the domain number
-      !   This will be used to decide whether to abort MPI
+      ! Store the domain number and initialized_mpi
+      !   This will be used to number the log files
       mpas_log_info % domainID = domain % domainID
       write(domainString, '(i4.4)') mpas_log_info % domainID
+
+      !   This will be used to decide whether to abort MPI
+      mpas_log_info % initialized_mpi = domain % dminfo % initialized_mpi
 
       ! Set log file to be active or not based on master/nonmaster task and optimized/debug build
       !   * Optimized build: Only master task log is active
@@ -281,8 +284,9 @@ module mpas_log
          mpas_log_info % outputLog % unitNum = unitNumber
          call mpas_new_unit(unitNumber)
          mpas_log_info % errorLog % unitNum = unitNumber
-         if ( unitNumber < 0 ) &
+         if ( unitNumber < 0 ) then
             call mpas_dmpar_global_abort('ERROR: All file units are taken.  Change maxUnits in mpas_io_units.F')
+         end if
 
       endif
 
@@ -432,9 +436,10 @@ module mpas_log
          write(unitNumber, '(a)') '----------------------------------------------------------------------'
          write(unitNumber, '(a,a,a,a,a,i7.1,a,i7.1)') 'Beginning MPAS-', trim(mpas_log_info % coreName), ' ', &
             trim(logTypeString), ' Log File for task ', mpas_log_info % taskID, ' of ', mpas_log_info % nTasks
-         if ( mpas_log_info % domainID > 0 ) &
+         if ( mpas_log_info % domainID > 0 ) then
             write(unitNumber, '(a,i7.1)') &
                ' for domain number ',  mpas_log_info % domainID
+         end if
          call date_and_time(date,time)
          write(unitNumber, '(a)') '    Opened at ' // date(1:4)//'/'//date(5:6)//'/'//date(7:8) // &
             ' ' // time(1:2)//':'//time(3:4)//':'//time(5:6)
@@ -846,8 +851,9 @@ module mpas_log
       deallocate(mpas_log_info)
 
 #ifdef _MPI
-      if ( mpas_log_info % domainID == 0 ) &
+      if ( mpas_log_info % initialized_mpi ) then
          call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
+      end if
 #else
       stop
 #endif

--- a/src/framework/mpas_log_types.inc
+++ b/src/framework/mpas_log_types.inc
@@ -28,6 +28,7 @@
                    !< (stored here to eliminate the need for dminfo later)
       character(len=StrKIND) :: coreName  !< name of the core to which this log manager instance belongs
       integer :: domainID !< domain number for this instance of the log manager
+      logical :: initialized_mpi
 
       integer :: outputMessageCount  !< counter for number of output messages printed during the run
       integer :: warningMessageCount  !< counter for number of warning messages printed during the run


### PR DESCRIPTION
The initialized_mpi logical is added to the mpas_log_type
in order to enable proper internal or external shutdown of
MPI.  Multiple domain instances are allowed for MPI
communicators initialized internally or externally.

Small changes in syntax as well.

